### PR TITLE
Fix model downloading by adding MODEL_DIR constant to predict.py

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -18,6 +18,9 @@ from modelscope import snapshot_download
 
 
 # Constants
+MODEL_DIR = "models"
+
+
 class Predictor(BasePredictor):
     def setup(self):
         """Load the model into memory to make running multiple predictions efficient"""


### PR DESCRIPTION
To fix this error:

```
Running 'script/download-weights' in Docker with the current directory mounted as a volume...
2024-06-04 02:45:17,718 - modelscope - INFO - PyTorch version 2.3.0 Found.
2024-06-04 02:45:17,718 - modelscope - INFO - Loading ast index from /root/.cache/modelscope/ast_indexer
2024-06-04 02:45:17,718 - modelscope - INFO - No valid ast index found from /root/.cache/modelscope/ast_indexer, generating ast index from prebuilt!
2024-06-04 02:45:17,767 - modelscope - INFO - Loading done! Current index file version is 1.14.0, with md5 3f6ec122acf0b4a9eedbda2efa69b78f and a total number of 976 components indexed
Traceback (most recent call last):
  File "/src/script/download-weights", line 11, in <module>
    from predict import MODEL_DIR
ImportError: cannot import name 'MODEL_DIR' from 'predict' (/src/predict.py)
ⅹ exit status 1
```

Which may have been introduced with [the last update to the model downloading script](https://github.com/thlz998/replicate-chattts/commit/4e9b5ac9c5bebcf20d424f00cf79092ee8041d96#diff-3496996311945a4cde1ad9c0270c3152e1a7e8ee39ffe6494f16d7e2041d874fL19-R11)